### PR TITLE
feat(spray): UI/UX overhaul - layout fixes, toolbar simplification, premium polish

### DIFF
--- a/src/components/den/RailSlots.tsx
+++ b/src/components/den/RailSlots.tsx
@@ -122,7 +122,7 @@ function useIsDesktop() {
     if (typeof window === "undefined") {
       return;
     }
-    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
     const handleChange = () => {
       setIsDesktop(mediaQuery.matches);
     };

--- a/src/components/modules/spray/PastePreviewModal.tsx
+++ b/src/components/modules/spray/PastePreviewModal.tsx
@@ -256,7 +256,7 @@ export function PastePreviewModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
       <div
         ref={modalRef}
-        className="relative flex max-h-[calc(100dvh-var(--app-header-height)-24px)] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#0a0a0a] shadow-2xl"
+        className="relative flex max-h-[calc(100dvh-var(--app-header-height)-24px)] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-den-bg shadow-2xl"
       >
         <div className="flex items-start justify-between gap-4 px-6 pt-6">
           <div>
@@ -301,7 +301,7 @@ export function PastePreviewModal({
                 value={text}
                 onChange={(event) => setText(event.target.value)}
                 placeholder="0xabc...,0.25"
-                className="min-h-[260px] w-full rounded-xl border border-wolf-border bg-[#0f141d] px-4 py-3 text-sm text-white/80 placeholder:text-white/30 focus:border-wolf-emerald focus:outline-none"
+                className="min-h-[260px] w-full rounded-xl border border-wolf-border bg-wolf-panel px-4 py-3 text-sm text-white/80 placeholder:text-white/30 focus:border-wolf-emerald focus:outline-none"
               />
               {mode === "same" && hasDetectedAmounts ? (
                 <div className="flex flex-wrap items-center gap-2 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
@@ -328,7 +328,7 @@ export function PastePreviewModal({
               ) : null}
             </div>
 
-            <div className="flex min-h-0 flex-col rounded-xl border border-wolf-border bg-[#0f141d] p-4">
+            <div className="flex min-h-0 flex-col rounded-xl border border-wolf-border bg-wolf-panel p-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold text-white">Preview</h3>
                 <button
@@ -548,7 +548,7 @@ export function PastePreviewModal({
           ) : null}
         </div>
 
-        <div className="sticky bottom-0 z-10 mt-auto border-t border-white/10 bg-[#0a0a0a] px-6 py-4">
+        <div className="sticky bottom-0 z-10 mt-auto border-t border-white/10 bg-den-bg px-6 py-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <button
               type="button"
@@ -579,7 +579,7 @@ export function PastePreviewModal({
                 type="button"
                 onClick={hasIssues ? handleFixAndApply : handleApplyAsIs}
                 disabled={hasIssues ? !canApplyFixes : !canApplyAsIs}
-                className="rounded-md border border-[#4ca22a] bg-[#89e24a] px-5 py-2 text-xs font-semibold uppercase text-[#09140a] transition hover:shadow-[0_12px_30px_rgba(186,255,92,0.4)] disabled:border-wolf-border disabled:bg-wolf-border disabled:text-white/40"
+                className="rounded-md border border-den-lime-dark bg-den-lime-deep px-5 py-2 text-xs font-semibold uppercase text-den-bg transition hover:shadow-[0_12px_30px_rgba(186,255,92,0.4)] disabled:border-wolf-border disabled:bg-wolf-border disabled:text-white/40"
               >
                 {hasIssues ? "Fix & Apply (recommended)" : "Apply"}
               </button>

--- a/src/components/modules/spray/RecipientsCard.tsx
+++ b/src/components/modules/spray/RecipientsCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import type {
   AmountMode,
@@ -38,9 +39,6 @@ type RecipientsCardProps = {
   fillMissingValue: string;
   onFillMissingValueChange: (value: string) => void;
   onPasteOpen?: (source: "paste" | "csv") => void;
-  primaryActionLabel?: string;
-  primaryActionDisabled?: boolean;
-  onPrimaryAction?: () => void;
   onEvent?: (type: SprayEventType, metadata?: Record<string, unknown>) => void;
   footer: React.ReactNode;
 };
@@ -71,12 +69,10 @@ export function RecipientsCard({
   fillMissingValue,
   onFillMissingValueChange,
   onPasteOpen,
-  primaryActionLabel,
-  primaryActionDisabled,
-  onPrimaryAction,
   onEvent,
   footer,
 }: RecipientsCardProps) {
+  const t = useTranslations("SprayDisperser");
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [previewText, setPreviewText] = useState("");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -160,19 +156,6 @@ export function RecipientsCard({
   }, [showOverflow]);
 
   const hasRecipients = recipientCount > 0;
-  const primaryLabel = hasRecipients
-    ? (primaryActionLabel ?? "Send")
-    : "Paste list";
-  const handlePrimaryAction = () => {
-    if (!hasRecipients) {
-      openPasteModal();
-      return;
-    }
-    onPrimaryAction?.();
-  };
-  const primaryDisabled = hasRecipients
-    ? Boolean(primaryActionDisabled)
-    : false;
 
   return (
     <section className="wolf-card--muted flex min-h-0 flex-1 flex-col border border-wolf-border-mid p-5">
@@ -190,34 +173,10 @@ export function RecipientsCard({
         <div className="flex flex-wrap items-center gap-2">
           <button
             type="button"
-            onClick={handlePrimaryAction}
-            disabled={primaryDisabled}
-            className="rounded-md border border-[#4ca22a] bg-[#89e24a] px-4 py-2 text-xs font-semibold uppercase text-[#09140a] transition hover:shadow-[0_12px_30px_rgba(186,255,92,0.4)] disabled:border-wolf-border disabled:bg-wolf-border disabled:text-white/40"
-          >
-            {primaryLabel}
-          </button>
-          {hasRecipients ? (
-            <button
-              type="button"
-              onClick={openPasteModal}
-              className="rounded-md border border-wolf-border px-3 py-2 text-xs font-semibold text-white/80 transition hover:border-wolf-border-strong hover:text-white"
-            >
-              Paste list
-            </button>
-          ) : null}
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
+            onClick={openPasteModal}
             className="rounded-md border border-wolf-border px-3 py-2 text-xs font-semibold text-white/80 transition hover:border-wolf-border-strong hover:text-white"
           >
-            Import CSV
-          </button>
-          <button
-            type="button"
-            onClick={onAddRow}
-            className="rounded-md border border-dashed border-wolf-border px-3 py-2 text-xs font-semibold text-white/70 transition hover:border-wolf-border-strong hover:text-white"
-          >
-            + Add manual
+            Paste list
           </button>
           <div ref={overflowRef} className="relative">
             <button
@@ -230,7 +189,27 @@ export function RecipientsCard({
               ⋯
             </button>
             {showOverflow ? (
-              <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-48 rounded-xl border border-wolf-border bg-[#0b111a] p-2 text-xs text-white/80 shadow-2xl">
+              <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-48 rounded-xl border border-wolf-border bg-wolf-panel p-2 text-xs text-white/80 shadow-2xl">
+                <button
+                  type="button"
+                  onClick={() => {
+                    fileInputRef.current?.click();
+                    setShowOverflow(false);
+                  }}
+                  className="w-full rounded-lg px-3 py-2 text-left transition hover:bg-white/5"
+                >
+                  Import CSV
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onAddRow();
+                    setShowOverflow(false);
+                  }}
+                  className="w-full rounded-lg px-3 py-2 text-left transition hover:bg-white/5"
+                >
+                  + Add manual
+                </button>
                 <button
                   type="button"
                   onClick={() => {
@@ -241,169 +220,208 @@ export function RecipientsCard({
                 >
                   Download template
                 </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    onClearRows();
-                    setShowOverflow(false);
-                  }}
-                  className="w-full rounded-lg px-3 py-2 text-left text-rose-200 transition hover:bg-white/5"
-                >
-                  Clear list
-                </button>
+                {hasRecipients ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onClearRows();
+                      setShowOverflow(false);
+                    }}
+                    className="w-full rounded-lg px-3 py-2 text-left text-rose-200 transition hover:bg-white/5"
+                  >
+                    Clear list
+                  </button>
+                ) : null}
               </div>
             ) : null}
           </div>
         </div>
       </div>
 
-      {(duplicateCount > 0 || invalidCount > 0 || missingAmountCount > 0) && (
-        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
-          {duplicateCount > 0 ? (
-            <>
-              <span className="text-amber-200">
-                {`${duplicateCount} duplicate row(s)`}
-              </span>
-              <div className="flex flex-wrap items-center gap-1 rounded-md border border-white/10 bg-white/5 px-1 text-[10px] uppercase text-white/60">
-                <button
-                  type="button"
-                  onClick={() => setDedupeStrategy("keep_first")}
-                  className={`rounded px-2 py-1 transition ${
-                    dedupeStrategy === "keep_first"
-                      ? "bg-wolf-neutral-soft text-white"
-                      : ""
-                  }`}
-                >
-                  Keep first
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setDedupeStrategy("keep_last")}
-                  className={`rounded px-2 py-1 transition ${
-                    dedupeStrategy === "keep_last"
-                      ? "bg-wolf-neutral-soft text-white"
-                      : ""
-                  }`}
-                >
-                  Keep last
-                </button>
-                {amountMode === "custom" ? (
+      {hasRecipients ? (
+        <>
+          {(duplicateCount > 0 ||
+            invalidCount > 0 ||
+            missingAmountCount > 0) && (
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+              {duplicateCount > 0 ? (
+                <>
+                  <span className="text-amber-200">
+                    {`${duplicateCount} duplicate row(s)`}
+                  </span>
+                  <div className="flex flex-wrap items-center gap-1 rounded-md border border-white/10 bg-white/5 px-1 text-[10px] uppercase text-white/60">
+                    <button
+                      type="button"
+                      onClick={() => setDedupeStrategy("keep_first")}
+                      className={`rounded px-2 py-1 transition ${
+                        dedupeStrategy === "keep_first"
+                          ? "bg-wolf-neutral-soft text-white"
+                          : ""
+                      }`}
+                    >
+                      Keep first
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setDedupeStrategy("keep_last")}
+                      className={`rounded px-2 py-1 transition ${
+                        dedupeStrategy === "keep_last"
+                          ? "bg-wolf-neutral-soft text-white"
+                          : ""
+                      }`}
+                    >
+                      Keep last
+                    </button>
+                    {amountMode === "custom" ? (
+                      <button
+                        type="button"
+                        onClick={() => setDedupeStrategy("merge_sum")}
+                        className={`rounded px-2 py-1 transition ${
+                          dedupeStrategy === "merge_sum"
+                            ? "bg-wolf-neutral-soft text-white"
+                            : ""
+                        }`}
+                      >
+                        Merge same address (sum)
+                      </button>
+                    ) : null}
+                  </div>
                   <button
                     type="button"
-                    onClick={() => setDedupeStrategy("merge_sum")}
-                    className={`rounded px-2 py-1 transition ${
-                      dedupeStrategy === "merge_sum"
-                        ? "bg-wolf-neutral-soft text-white"
-                        : ""
-                    }`}
+                    onClick={() => onRemoveDuplicates(dedupeStrategy)}
+                    className="rounded-md border border-amber-400/40 px-2 py-1 text-[11px] font-semibold uppercase text-amber-200 transition hover:border-amber-300 hover:text-amber-100"
                   >
-                    Merge same address (sum)
+                    Resolve duplicate rows
                   </button>
-                ) : null}
-              </div>
-              <button
-                type="button"
-                onClick={() => onRemoveDuplicates(dedupeStrategy)}
-                className="rounded-md border border-amber-400/40 px-2 py-1 text-[11px] font-semibold uppercase text-amber-200 transition hover:border-amber-300 hover:text-amber-100"
-              >
-                Resolve duplicate rows
-              </button>
-            </>
-          ) : null}
-          {invalidCount > 0 ? (
-            <>
-              <span className="text-rose-200">{`${invalidCount} invalid`}</span>
-              <button
-                type="button"
-                onClick={onRemoveInvalidRows}
-                className="rounded-md border border-rose-400/40 px-2 py-1 text-[11px] font-semibold uppercase text-rose-200 transition hover:border-rose-300 hover:text-rose-100"
-              >
-                Remove invalid rows
-              </button>
-            </>
-          ) : null}
-          {missingAmountCount > 0 ? (
-            <>
-              <span className="text-amber-200">
-                {`${missingAmountCount} missing amounts`}
-              </span>
-              <input
-                value={fillMissingValue}
-                onChange={(event) =>
-                  onFillMissingValueChange(event.target.value)
-                }
-                placeholder="Fill value"
-                className="h-7 w-28 rounded-md border border-amber-400/30 bg-wolf-panel px-2 text-[11px] text-white/80 placeholder:text-white/40 focus:border-wolf-emerald focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={onFillMissingAmounts}
-                disabled={!canFillMissing}
-                className="rounded-md border border-amber-400/40 px-2 py-1 text-[11px] font-semibold uppercase text-amber-200 transition hover:border-amber-300 hover:text-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Fill missing amounts
-              </button>
-            </>
-          ) : null}
-        </div>
-      )}
+                </>
+              ) : null}
+              {invalidCount > 0 ? (
+                <>
+                  <span className="text-rose-200">{`${invalidCount} invalid`}</span>
+                  <button
+                    type="button"
+                    onClick={onRemoveInvalidRows}
+                    className="rounded-md border border-rose-400/40 px-2 py-1 text-[11px] font-semibold uppercase text-rose-200 transition hover:border-rose-300 hover:text-rose-100"
+                  >
+                    Remove invalid rows
+                  </button>
+                </>
+              ) : null}
+              {missingAmountCount > 0 ? (
+                <>
+                  <span className="text-amber-200">
+                    {`${missingAmountCount} missing amounts`}
+                  </span>
+                  <input
+                    value={fillMissingValue}
+                    onChange={(event) =>
+                      onFillMissingValueChange(event.target.value)
+                    }
+                    placeholder="Fill value"
+                    className="h-7 w-28 rounded-md border border-amber-400/30 bg-wolf-panel px-2 text-[11px] text-white/80 placeholder:text-white/40 focus:border-wolf-emerald focus:outline-none"
+                  />
+                  <button
+                    type="button"
+                    onClick={onFillMissingAmounts}
+                    disabled={!canFillMissing}
+                    className="rounded-md border border-amber-400/40 px-2 py-1 text-[11px] font-semibold uppercase text-amber-200 transition hover:border-amber-300 hover:text-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Fill missing amounts
+                  </button>
+                </>
+              ) : null}
+            </div>
+          )}
 
-      <div className="mt-5 flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-1 rounded-lg border border-wolf-border bg-wolf-panel px-1.5 py-1 text-xs font-semibold uppercase text-wolf-text-subtle">
-          <button
-            type="button"
-            onClick={() => onModeChange("same")}
-            className={`rounded-md px-3 py-1 transition ${
-              amountMode === "same"
-                ? "bg-wolf-neutral-soft text-white"
-                : "text-wolf-text-subtle"
-            }`}
-          >
-            Same amount
-          </button>
-          <button
-            type="button"
-            onClick={() => onModeChange("custom")}
-            className={`rounded-md px-3 py-1 transition ${
-              amountMode === "custom"
-                ? "bg-[linear-gradient(135deg,rgba(160,83,255,0.85),rgba(91,45,255,0.65))] text-white"
-                : "text-wolf-text-subtle"
-            }`}
-          >
-            Custom amounts
-          </button>
-        </div>
-        {amountMode === "same" ? (
-          <div className="flex min-w-[220px] flex-1 items-center gap-2">
-            <label
-              htmlFor="global-amount"
-              className="text-xs uppercase text-white/50"
-            >
-              Amount per recipient
-            </label>
-            <input
-              id="global-amount"
-              value={globalAmount}
-              onChange={(event) => onGlobalAmountChange(event.target.value)}
-              placeholder="0.00"
-              className="flex-1 rounded-md border border-wolf-border bg-wolf-panel px-3 py-2 text-sm text-white/80 placeholder:text-white/30 focus:border-wolf-emerald focus:outline-none"
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-1 rounded-lg border border-wolf-border bg-wolf-panel px-1.5 py-1 text-xs font-semibold uppercase text-wolf-text-subtle">
+              <button
+                type="button"
+                onClick={() => onModeChange("same")}
+                className={`rounded-md px-3 py-1 transition ${
+                  amountMode === "same"
+                    ? "bg-wolf-neutral-soft text-white"
+                    : "text-wolf-text-subtle"
+                }`}
+              >
+                Same amount
+              </button>
+              <button
+                type="button"
+                onClick={() => onModeChange("custom")}
+                className={`rounded-md px-3 py-1 transition ${
+                  amountMode === "custom"
+                    ? "bg-[linear-gradient(135deg,rgba(160,83,255,0.85),rgba(91,45,255,0.65))] text-white"
+                    : "text-wolf-text-subtle"
+                }`}
+              >
+                Custom amounts
+              </button>
+            </div>
+            {amountMode === "same" ? (
+              <div className="flex min-w-[220px] flex-1 items-center gap-2">
+                <label
+                  htmlFor="global-amount"
+                  className="text-xs uppercase text-white/50"
+                >
+                  Amount per recipient
+                </label>
+                <input
+                  id="global-amount"
+                  value={globalAmount}
+                  onChange={(event) => onGlobalAmountChange(event.target.value)}
+                  placeholder="0.00"
+                  className="flex-1 rounded-md border border-wolf-border bg-wolf-panel px-3 py-2 text-sm text-white/80 placeholder:text-white/30 focus:border-wolf-emerald focus:outline-none"
+                />
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-4 flex min-h-0 flex-1">
+            <RecipientsTable
+              rows={rows}
+              amountMode={amountMode}
+              statusById={statusById}
+              issuesById={issuesById}
+              onRowChange={onRowChange}
+              onRemoveRow={onRemoveRow}
+              onAddRow={onAddRow}
+              footer={footer}
             />
           </div>
-        ) : null}
-      </div>
-
-      <div className="mt-4 flex min-h-0 flex-1">
-        <RecipientsTable
-          rows={rows}
-          amountMode={amountMode}
-          statusById={statusById}
-          issuesById={issuesById}
-          onRowChange={onRowChange}
-          onRemoveRow={onRemoveRow}
-          onAddRow={onAddRow}
-          footer={footer}
-        />
-      </div>
+        </>
+      ) : (
+        <div className="mt-6 flex flex-1 flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-wolf-border px-6 py-16 text-center">
+          <svg
+            viewBox="0 0 24 24"
+            className="h-10 w-10 text-white/20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+            <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+          </svg>
+          <div>
+            <p className="text-sm font-semibold text-white/70">
+              {t("empty.title")}
+            </p>
+            <p className="mt-1 max-w-[36ch] text-xs text-white/40">
+              {t("empty.description")}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={openPasteModal}
+            className="rounded-lg border border-wolf-border bg-wolf-panel px-5 py-2.5 text-xs font-semibold text-white/80 transition hover:border-wolf-border-strong hover:text-white"
+          >
+            Paste list
+          </button>
+        </div>
+      )}
 
       <PastePreviewModal
         isOpen={isPreviewOpen}

--- a/src/components/modules/spray/RecipientsTable.tsx
+++ b/src/components/modules/spray/RecipientsTable.tsx
@@ -144,14 +144,14 @@ export function RecipientsTable({
 
   const gridTemplate =
     amountMode === "custom"
-      ? "grid-cols-[minmax(220px,1fr)_120px_110px_44px]"
-      : "grid-cols-[minmax(220px,1fr)_110px_44px]";
+      ? "grid-cols-[minmax(120px,1fr)_80px_36px] sm:grid-cols-[minmax(220px,1fr)_120px_110px_44px]"
+      : "grid-cols-[minmax(120px,1fr)_36px] sm:grid-cols-[minmax(220px,1fr)_110px_44px]";
   const rowTextSize = density === "compact" ? "text-xs" : "text-sm";
   const rowPadding = density === "compact" ? "py-1.5" : "py-2";
   const inputHeight = density === "compact" ? "h-8 text-xs" : "h-9 text-sm";
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-wolf-border bg-[#0b111a]">
+    <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-wolf-border bg-den-bg">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-wolf-border px-4 py-2 text-[11px] uppercase text-white/60">
         <div className="flex flex-wrap items-center gap-2">
           {filterOptions.map((option) => (
@@ -193,7 +193,7 @@ export function RecipientsTable({
         {amountMode === "custom" ? (
           <span className="text-right">Amount</span>
         ) : null}
-        <span>Status</span>
+        <span className="hidden sm:inline">Status</span>
         <span className="text-right">Actions</span>
       </div>
 
@@ -276,7 +276,7 @@ export function RecipientsTable({
                     />
                   ) : null}
                   <span
-                    className={`text-xs font-semibold ${statusTone(status)}`}
+                    className={`hidden text-xs font-semibold sm:inline ${statusTone(status)}`}
                   >
                     {statusLabel(status)}
                   </span>
@@ -345,7 +345,7 @@ export function RecipientsTable({
                     />
                   ) : null}
                   <span
-                    className={`text-xs font-semibold ${statusTone(status)}`}
+                    className={`hidden text-xs font-semibold sm:inline ${statusTone(status)}`}
                   >
                     {statusLabel(status)}
                   </span>
@@ -377,7 +377,7 @@ export function RecipientsTable({
         )}
 
         {footer ? (
-          <div className="sticky bottom-0 z-10 border-t border-wolf-border bg-[#0b111a] shadow-[0_-10px_24px_rgba(2,6,12,0.75)]">
+          <div className="sticky bottom-0 z-10 border-t border-wolf-border bg-den-bg shadow-[0_-10px_24px_rgba(2,6,12,0.75)]">
             {footer}
           </div>
         ) : null}

--- a/src/components/modules/spray/ReplaceConfirmDialog.tsx
+++ b/src/components/modules/spray/ReplaceConfirmDialog.tsx
@@ -51,7 +51,7 @@ export function ReplaceConfirmDialog({
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm">
       <div
         ref={dialogRef}
-        className="w-full max-w-md rounded-2xl border border-white/10 bg-[#0a0a0a] p-6 shadow-2xl"
+        className="w-full max-w-md rounded-2xl border border-white/10 bg-den-bg p-6 shadow-2xl"
       >
         <h3 className="text-lg font-semibold text-white">
           Replace existing recipients?

--- a/src/components/modules/spray/SprayLogModal.tsx
+++ b/src/components/modules/spray/SprayLogModal.tsx
@@ -92,7 +92,7 @@ export function SprayLogModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
       <div
         ref={modalRef}
-        className="relative flex max-h-[calc(100dvh-var(--app-header-height)-24px)] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#0a0a0a] shadow-2xl"
+        className="relative flex max-h-[calc(100dvh-var(--app-header-height)-24px)] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-den-bg shadow-2xl"
       >
         <div className="flex items-start justify-between gap-4 border-b border-white/10 px-6 py-5">
           <div>
@@ -144,7 +144,7 @@ export function SprayLogModal({
                 return (
                   <li
                     key={event.id}
-                    className="rounded-xl border border-wolf-border bg-[#0f141d] px-4 py-3"
+                    className="rounded-xl border border-wolf-border bg-wolf-panel px-4 py-3"
                   >
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <p className="text-sm font-semibold text-white">

--- a/src/components/modules/spray/StickyFooter.tsx
+++ b/src/components/modules/spray/StickyFooter.tsx
@@ -22,9 +22,9 @@ export function StickyFooter({
   isLoading,
 }: StickyFooterProps) {
   return (
-    <div className="border-t border-wolf-border bg-[#0a0f17]/95 px-4 py-4 backdrop-blur">
-      <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-white/70">
-        <div className="flex flex-wrap items-center gap-4">
+    <div className="border-t border-wolf-border bg-den-bg/95 px-4 py-4 backdrop-blur">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between text-xs text-white/70">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
           <span>{`Wallets: ${recipientCount}`}</span>
           <span>{totalLabel}</span>
           {feeLabel ? <span>{feeLabel}</span> : null}
@@ -34,7 +34,7 @@ export function StickyFooter({
           type="button"
           onClick={onPrimaryAction}
           disabled={ctaDisabled}
-          className="inline-flex items-center gap-2 rounded-xl border border-[#4ca22a] bg-[#89e24a] px-5 py-2 text-[0.75rem] font-semibold uppercase text-[#09140a] shadow-[0_0_20px_rgba(186,255,92,0.35)] transition hover:-translate-y-0.5 hover:shadow-[0_16px_40px_rgba(186,255,92,0.45)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#baff5c] disabled:translate-y-0 disabled:border-wolf-border disabled:bg-wolf-border disabled:text-white/40 disabled:shadow-none"
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl border border-den-lime-dark bg-den-lime-deep px-5 py-2 text-[0.75rem] font-semibold uppercase text-den-bg shadow-[var(--den-shadow-glow-accent)] transition hover:-translate-y-0.5 hover:shadow-[0_16px_40px_rgba(186,255,92,0.45)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-den-lime disabled:translate-y-0 disabled:border-wolf-border disabled:bg-wolf-border disabled:text-white/40 disabled:shadow-none w-full sm:w-auto"
         >
           {isLoading ? (
             <svg

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1198,6 +1198,10 @@
     "badge": "Spray Rewards",
     "heading": "Send rewards in one clean shot",
     "description": "Paste wallets, pick a network, and Spray rewards in one go instead of sending them one by one.",
+    "empty": {
+      "title": "No recipients yet",
+      "description": "Paste a list of wallet addresses or import a CSV to get started with your Spray."
+    },
     "actions": {
       "connect": "Connect Wallet",
       "connected": "{network}: {address}",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1198,6 +1198,10 @@
     "badge": "Consola Spray",
     "heading": "Envía recompensas en un solo disparo",
     "description": "Pega las wallets, elige la red y dispersa recompensas en un único envío en vez de hacerlo una por una.",
+    "empty": {
+      "title": "Sin destinatarios",
+      "description": "Pega una lista de direcciones de wallet o importa un CSV para comenzar con tu Spray."
+    },
     "actions": {
       "connect": "Conectar wallet",
       "connected": "{network}: {address}",

--- a/src/modules/spray/SprayLayout.tsx
+++ b/src/modules/spray/SprayLayout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 import { useMemo } from "react";
 import { DenMain, DenRightRail } from "@/components/den/RailSlots";
@@ -179,10 +180,73 @@ export default function SprayLayout() {
         )
       : null;
 
+  const sendReady =
+    recipients.recipientCount > 0 &&
+    !recipients.hasBlockingIssues &&
+    !ctaDisabled;
+
+  const progressSteps = [
+    { label: "Network", done: true },
+    { label: "Token", done: true },
+    { label: "Recipients", done: recipients.recipientCount > 0 },
+    { label: "Ready", done: sendReady },
+  ];
+
+  const allowanceDisplay =
+    token.mode === "token"
+      ? transaction.allowanceStatus === "approved"
+        ? "Ready"
+        : transaction.allowanceStatus === "needs_approval"
+          ? "Needs approval"
+          : transaction.allowanceStatus === "loading"
+            ? "Checking"
+            : "Not checked"
+      : "Not required";
+
   const summaryPanel = (
-    <div className="wolf-card--muted border border-wolf-border px-5 py-4 text-xs text-white/70">
-      <p className="text-xs uppercase text-wolf-text-subtle">Summary</p>
-      <div className="mt-3 space-y-2">
+    <div
+      className={`wolf-card border border-wolf-border px-5 py-5 text-xs text-white/70 ${sendReady ? "shadow-[var(--den-shadow-glow-accent)]" : ""}`}
+    >
+      <div className="flex items-center gap-3">
+        <Image
+          src={selectedNetworkBadgeIcon}
+          alt={`${network.selectedNetwork.name} icon`}
+          width={28}
+          height={28}
+          className="h-7 w-7 object-contain"
+        />
+        <div>
+          <p className="text-[10px] uppercase text-wolf-text-subtle">Network</p>
+          <p className="text-sm font-semibold text-white">
+            {network.selectedNetwork.name}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-2">
+        {progressSteps.map((step) => (
+          <div
+            key={step.label}
+            className="flex flex-1 flex-col items-center gap-1"
+          >
+            <div
+              className={`h-1.5 w-full rounded-full transition ${step.done ? "bg-wolf-emerald" : "bg-white/10"}`}
+            />
+            <span
+              className={`text-[9px] uppercase ${step.done ? "text-wolf-emerald" : "text-white/30"}`}
+            >
+              {step.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-5 rounded-xl border border-wolf-border bg-wolf-panel/60 px-4 py-3 text-center">
+        <p className="text-[10px] uppercase text-wolf-text-subtle">Total</p>
+        <p className="mt-1 text-lg font-bold text-white">{totalDisplay}</p>
+      </div>
+
+      <div className="mt-4 space-y-2">
         <div className="flex items-center justify-between gap-3">
           <span>Recipients</span>
           <span className="font-semibold text-white">
@@ -190,22 +254,12 @@ export default function SprayLayout() {
           </span>
         </div>
         <div className="flex items-center justify-between gap-3">
-          <span>Total</span>
-          <span className="font-semibold text-white">{totalDisplay}</span>
+          <span>Balance</span>
+          <span className="text-white/80">{nativeBalanceDisplay}</span>
         </div>
         <div className="flex items-center justify-between gap-3">
           <span>Allowance</span>
-          <span className="text-white/80">
-            {token.mode === "token"
-              ? transaction.allowanceStatus === "approved"
-                ? "Ready"
-                : transaction.allowanceStatus === "needs_approval"
-                  ? "Needs approval"
-                  : transaction.allowanceStatus === "loading"
-                    ? "Checking"
-                    : "Not checked"
-              : "Not required"}
-          </span>
+          <span className="text-white/80">{allowanceDisplay}</span>
         </div>
         <div className="flex items-center justify-between gap-3">
           <span>Last spray</span>
@@ -233,12 +287,7 @@ export default function SprayLayout() {
     <>
       <DenMain>
         <div className="text-wolf-foreground">
-          <div
-            className="mx-auto flex w-full max-w-[1120px] min-h-0 flex-col gap-5 overflow-hidden"
-            style={{
-              maxHeight: "calc(100dvh - var(--app-header-height) - 24px)",
-            }}
-          >
+          <div className="mx-auto flex w-full max-w-[1120px] min-h-0 flex-col gap-5 overflow-y-auto">
             <div className="shadow-[0_45px_120px_-70px_rgba(160,83,255,0.35)]">
               <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                 <div className="flex flex-col items-start gap-2 text-sm text-white/80">
@@ -300,50 +349,58 @@ export default function SprayLayout() {
                     </button>
                   </div>
 
-                  <NetworkSelector
-                    selectedNetworkKey={network.selectedNetworkKey}
-                    selectedNetworkName={network.selectedNetwork.name}
-                    isOpen={network.isNetworkDropdownOpen}
-                    setIsOpen={network.setIsNetworkDropdownOpen}
-                    onSelect={network.selectNetwork}
-                    label={networkSelectorLabel}
-                    badgeIcon={selectedNetworkBadgeIcon}
-                  />
+                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-4">
+                    <NetworkSelector
+                      selectedNetworkKey={network.selectedNetworkKey}
+                      selectedNetworkName={network.selectedNetwork.name}
+                      isOpen={network.isNetworkDropdownOpen}
+                      setIsOpen={network.setIsNetworkDropdownOpen}
+                      onSelect={network.selectNetwork}
+                      label={networkSelectorLabel}
+                      badgeIcon={selectedNetworkBadgeIcon}
+                      onOpenChange={(open) => {
+                        if (open) token.setIsTrustedOpen(false);
+                      }}
+                    />
 
-                  <TokenSelector
-                    isOpen={token.isTrustedOpen}
-                    setIsOpen={token.setIsTrustedOpen}
-                    tokenCardIconSrc={token.tokenCardIconSrc}
-                    tokenCardSymbol={token.tokenCardSymbol}
-                    tokenCardPrimaryLabel={tokenCardPrimaryLabel}
-                    tokenPayWithLabel={tokenPayWithLabel}
-                    isCustomTokenSelected={token.isCustomTokenSelected}
-                    isNativeTokenSelected={token.isNativeTokenSelected}
-                    tokenAddress={token.tokenAddress}
-                    onTokenAddressChange={token.setTokenAddress}
-                    isFetchingTokenInfo={token.isFetchingTokenInfo}
-                    tokenInfo={token.tokenInfo}
-                    nativeTokenIconSrc={token.nativeTokenIconSrc}
-                    nativeTokenLabel={nativeTokenLabel}
-                    nativeSymbol={nativeSymbol}
-                    nativeBalanceDisplay={nativeBalanceDisplay}
-                    trustedTokens={token.trustedTokens}
-                    selectedTrustedToken={token.selectedTrustedToken}
-                    trustedTokenBalances={balances.trustedTokenBalances}
-                    signerAddress={wallet.signerAddress}
-                    walletBalanceConnectHint={walletBalanceConnectHint}
-                    walletBalanceLoadingLabel={walletBalanceLoadingLabel}
-                    tokenSymbolPlaceholder={tokenSymbolPlaceholder}
-                    customTokenNameLabel={customTokenNameLabel}
-                    onSelectNative={token.handleSelectNativeToken}
-                    onSelectCustom={token.handleSelectCustomToken}
-                    onSelectTrusted={token.handleSelectTrustedToken}
-                  />
+                    <TokenSelector
+                      isOpen={token.isTrustedOpen}
+                      setIsOpen={token.setIsTrustedOpen}
+                      onOpenChange={(open) => {
+                        if (open) network.setIsNetworkDropdownOpen(false);
+                      }}
+                      tokenCardIconSrc={token.tokenCardIconSrc}
+                      tokenCardSymbol={token.tokenCardSymbol}
+                      tokenCardPrimaryLabel={tokenCardPrimaryLabel}
+                      tokenPayWithLabel={tokenPayWithLabel}
+                      isCustomTokenSelected={token.isCustomTokenSelected}
+                      isNativeTokenSelected={token.isNativeTokenSelected}
+                      tokenAddress={token.tokenAddress}
+                      onTokenAddressChange={token.setTokenAddress}
+                      isFetchingTokenInfo={token.isFetchingTokenInfo}
+                      tokenInfo={token.tokenInfo}
+                      nativeTokenIconSrc={token.nativeTokenIconSrc}
+                      nativeTokenLabel={nativeTokenLabel}
+                      nativeSymbol={nativeSymbol}
+                      nativeBalanceDisplay={nativeBalanceDisplay}
+                      trustedTokens={token.trustedTokens}
+                      selectedTrustedToken={token.selectedTrustedToken}
+                      trustedTokenBalances={balances.trustedTokenBalances}
+                      signerAddress={wallet.signerAddress}
+                      walletBalanceConnectHint={walletBalanceConnectHint}
+                      walletBalanceLoadingLabel={walletBalanceLoadingLabel}
+                      tokenSymbolPlaceholder={tokenSymbolPlaceholder}
+                      customTokenNameLabel={customTokenNameLabel}
+                      onSelectNative={token.handleSelectNativeToken}
+                      onSelectCustom={token.handleSelectCustomToken}
+                      onSelectTrusted={token.handleSelectTrustedToken}
+                    />
+                  </div>
                 </section>
 
                 {/* ERC20 Transaction Steps Indicator */}
                 {transaction.erc20Steps.active && token.mode === "token" && (
-                  <div className="mt-4 rounded-2xl border border-wolf-border bg-[#0b111a] px-5 py-4">
+                  <div className="mt-4 rounded-2xl border border-wolf-border bg-den-bg px-5 py-4">
                     <p className="text-xs uppercase text-wolf-text-subtle mb-3">
                       Transaction Steps
                     </p>
@@ -437,7 +494,7 @@ export default function SprayLayout() {
 
                 {/* Batch Progress */}
                 {batchProgressVisible ? (
-                  <div className="mt-4 rounded-2xl border border-wolf-border bg-[#0b111a] px-5 py-4 text-xs text-white/70">
+                  <div className="mt-4 rounded-2xl border border-wolf-border bg-den-bg px-5 py-4 text-xs text-white/70">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div>
                         <p className="text-xs uppercase text-wolf-text-subtle">
@@ -484,12 +541,7 @@ export default function SprayLayout() {
                 ) : null}
 
                 {/* Recipients Card */}
-                <div
-                  className="mt-5 flex min-h-0 flex-1"
-                  style={{
-                    maxHeight: "calc(100dvh - var(--app-header-height) - 24px)",
-                  }}
-                >
+                <div className="mt-5 flex min-h-0 flex-1">
                   <RecipientsCard
                     rows={recipients.rows}
                     recipientCount={recipients.recipientCount}
@@ -517,11 +569,6 @@ export default function SprayLayout() {
                     onFillMissingValueChange={recipients.updateFillMissingValue}
                     onPasteOpen={telemetry.handlePasteOpen}
                     onEvent={telemetry.logSprayEvent}
-                    primaryActionLabel={
-                      recipients.recipientCount === 0 ? "Paste list" : ctaLabel
-                    }
-                    primaryActionDisabled={ctaDisabled}
-                    onPrimaryAction={transaction.handleSubmit}
                     footer={
                       <StickyFooter
                         recipientCount={recipients.recipientCount}

--- a/src/modules/spray/components/NetworkSelector.tsx
+++ b/src/modules/spray/components/NetworkSelector.tsx
@@ -13,6 +13,7 @@ type NetworkSelectorProps = {
   onSelect: (key: string) => void;
   label: string;
   badgeIcon: string;
+  onOpenChange?: (open: boolean) => void;
 };
 
 export function NetworkSelector({
@@ -23,6 +24,7 @@ export function NetworkSelector({
   onSelect,
   label,
   badgeIcon,
+  onOpenChange,
 }: NetworkSelectorProps) {
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
@@ -45,23 +47,27 @@ export function NetworkSelector({
   return (
     <div
       ref={dropdownRef}
-      className={`relative mt-4 w-full ${isOpen ? "z-50" : "z-30"}`}
+      className={`relative mt-4 w-full ${isOpen ? "z-50" : "z-auto"}`}
     >
       <button
         type="button"
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         aria-controls="network-selector-options"
-        onClick={() => setIsOpen((prev: boolean) => !prev)}
-        className="flex w-full items-center gap-3 rounded-xl border border-wolf-border bg-[#0f141d] px-4 py-3 text-left text-sm text-white/80 transition hover:border-wolf-emerald focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-wolf-emerald"
+        onClick={() => {
+          const next = !isOpen;
+          setIsOpen(next);
+          onOpenChange?.(next);
+        }}
+        className="flex w-full items-center gap-3 rounded-xl border border-wolf-border bg-wolf-panel px-4 py-2 text-left text-sm text-white/80 transition hover:border-wolf-emerald focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-wolf-emerald"
       >
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/10">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/10">
           <Image
             src={badgeIcon}
             alt={`${selectedNetworkName} badge`}
-            width={32}
-            height={32}
-            className="h-8 w-8 object-contain"
+            width={24}
+            height={24}
+            className="h-6 w-6 object-contain"
           />
         </div>
         <div className="flex-1 text-left leading-tight">

--- a/src/modules/spray/components/TokenSelector.tsx
+++ b/src/modules/spray/components/TokenSelector.tsx
@@ -41,6 +41,7 @@ type TokenSelectorProps = {
   onSelectNative: () => void;
   onSelectCustom: () => void;
   onSelectTrusted: (address: string) => void;
+  onOpenChange?: (open: boolean) => void;
 };
 
 export function TokenSelector({
@@ -71,6 +72,7 @@ export function TokenSelector({
   onSelectNative,
   onSelectCustom,
   onSelectTrusted,
+  onOpenChange,
 }: TokenSelectorProps) {
   const t = useTranslations("SprayDisperser");
   const dropdownRef = useRef<HTMLDivElement | null>(null);
@@ -92,11 +94,11 @@ export function TokenSelector({
   }, [isOpen, setIsOpen]);
 
   return (
-    <div className="mt-6 space-y-3">
+    <div className="mt-4 space-y-3 lg:mt-0">
       <div className="space-y-2">
         <div
           ref={dropdownRef}
-          className="relative z-30"
+          className={`relative ${isOpen ? "z-50" : "z-auto"}`}
           id="trusted-token-select"
         >
           <button
@@ -104,17 +106,21 @@ export function TokenSelector({
             aria-haspopup="listbox"
             aria-expanded={isOpen}
             aria-controls="trusted-token-options"
-            onClick={() => setIsOpen((v: boolean) => !v)}
+            onClick={() => {
+              const next = !isOpen;
+              setIsOpen(next);
+              onOpenChange?.(next);
+            }}
             title={tokenCardPrimaryLabel}
-            className="flex w-full items-center gap-3 rounded-xl border border-wolf-border bg-[#0f141d] px-3 py-2 text-left text-sm text-white/80 transition hover:border-wolf-emerald focus:border-wolf-emerald focus:outline-none"
+            className="flex w-full items-center gap-3 rounded-xl border border-wolf-border bg-wolf-panel px-3 py-2 text-left text-sm text-white/80 transition hover:border-wolf-emerald focus:border-wolf-emerald focus:outline-none"
           >
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/10">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/10">
               <Image
                 src={tokenCardIconSrc}
                 alt={`${tokenCardSymbol} token icon`}
-                width={32}
-                height={32}
-                className="h-8 w-8 object-contain"
+                width={24}
+                height={24}
+                className="h-6 w-6 object-contain"
               />
             </div>
             <div className="text-left leading-tight w-full">
@@ -169,7 +175,7 @@ export function TokenSelector({
             <div
               id="trusted-token-options"
               role="listbox"
-              className="absolute z-40 mt-2 w-full max-h-[18rem] overflow-y-auto rounded-xl border border-wolf-border bg-[#0b111a] py-1 text-sm text-white/80 shadow-2xl"
+              className="absolute z-40 mt-2 w-full max-h-[18rem] overflow-y-auto rounded-xl border border-wolf-border bg-den-bg py-1 text-sm text-white/80 shadow-2xl"
             >
               <button
                 type="button"


### PR DESCRIPTION
## Summary

- **Milestone 1 (Layout Fixes):** Remove double maxHeight clipping, fix right rail portal threshold (768px → 1024px), add dropdown mutual exclusion with standardized z-index
- **Milestone 2 (UX Simplification):** Consolidate CTA to StickyFooter only, move secondary actions to overflow menu, add empty state with i18n (EN/ES), compact selectors into 2-column grid
- **Milestone 3 (Premium Polish):** Replace all hardcoded hex colors with design tokens across 10 files, upgrade summary panel with network header/progress bar/glow, mobile-optimized layout with responsive grid and 44px touch targets

## Test plan

- [ ] Resize browser 400px → 1500px: no clipping, no overflow, summary falls back inline below 1024px
- [ ] Open Network dropdown → Token dropdown auto-closes (and vice versa)
- [ ] With 0 recipients: empty state shows clipboard icon + i18n text + Paste list CTA
- [ ] Toolbar shows only Paste list + overflow menu (Import CSV, Add manual, Download template, Clear list inside)
- [ ] Summary panel: network icon, 4-step progress bar, highlighted total, glow when send-ready
- [ ] Mobile: stacked CTA, hidden status column, full-width send button
- [ ] Switch locale to ES: empty state text renders in Spanish

Wolfcito 🐾 @akawolfcito